### PR TITLE
[packaging] Only BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/udisks2.spec
+++ b/rpm/udisks2.spec
@@ -65,9 +65,7 @@ Requires: libblockdev-swap   >= %{libblockdev_version}
 Requires: libblockdev-fs     >= %{libblockdev_version}
 Requires: libblockdev-crypto >= %{libblockdev_version}
 
-# Needed for the systemd-related macros used in this file
 %{?systemd_requires}
-BuildRequires: systemd
 
 # Needed to pull in the system bus daemon
 Requires: dbus >= %{dbus_version}


### PR DESCRIPTION
We already include systemd as BuildRequires lets drop it so the right systemd
variant gets installed into the builder.